### PR TITLE
Water 5861 fix rules being overwritten

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,6 +1,6 @@
 <?php
 
-$config = new UptimeProject\PhpCsFixerConfig\Config;
+$config = new SandwaveIo\PhpCsFixerConfig\Config;
 $config->getFinder()
     ->in(__DIR__ . "/src");
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 UptimeProject.io <support@uptimeproject.io>
+Copyright (c) 2020 Sandwave.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-<a href="https://uptimeproject.io" target="_blank"><img src="https://uptimeproject.io/img/logo.png" height="50px" /></a>
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sandwave-io/php-cs-fixer-config/CI?style=flat-square)
+![Packagist PHP Version Support](https://img.shields.io/packagist/php-v/sandwave-io/php-cs-fixer-config?style=flat-square)
+![Packagist PHP Version Support](https://img.shields.io/packagist/v/sandwave-io/php-cs-fixer-config?style=flat-square)
+![Packagist Downloads](https://img.shields.io/packagist/dt/sandwave-io/php-cs-fixer-config?style=flat-square)
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/uptimeproject/php-cs-fixer-config/CI?style=flat-square)
-![Packagist PHP Version Support](https://img.shields.io/packagist/php-v/uptimeproject/php-cs-fixer-config?style=flat-square)
-![Packagist PHP Version Support](https://img.shields.io/packagist/v/uptimeproject/php-cs-fixer-config?style=flat-square)
-![Packagist Downloads](https://img.shields.io/packagist/dt/uptimeproject/php-cs-fixer-config?style=flat-square)
-
-This is a shared [FriendsOfPHP/php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) configuration used primarily in UptimeProject.io projects. But feel free to use it in your projects if you would like. Also, if you want to propose a change, feel free to create a PR 😁
+This is a shared [FriendsOfPHP/php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) configuration used primarily in Sandwave.io projects. But feel free to use it in your projects if you would like. Also, if you want to propose a change, feel free to create a PR 😁
 
 This package can be used on PHP 7.4, 8.0 and 8.1.
 
 ## Installation
 
 ```sh
-composer require --dev uptimeproject/php-cs-fixer-config
+composer require --dev sandwave-io/php-cs-fixer-config
 ```
 
 ### PHP-CS-Fixer 2.0
@@ -20,7 +18,7 @@ composer require --dev uptimeproject/php-cs-fixer-config
 If you are still using v2.x of PHP-CS-Fixer in your project, you should use version <1.2.x of this package.
 
 ```sh
-composer require --dev uptimeproject/php-cs-fixer-config:1.2.*
+composer require --dev sandwave-io/php-cs-fixer-config:1.2.*
 ```
 
 Note that this version is no longer maintained, and you should upgrade to the latest version of PHP-CS-Fixer
@@ -32,7 +30,7 @@ Create a `.php-cs-fixer.php` configuration file in the root of your project.
 ```php
 <?php
 
-$config = new UptimeProject\PhpCsFixerConfig\Config;
+$config = new SandwaveIo\PhpCsFixerConfig\Config;
 $config->getFinder()
     ->in(__DIR__ . "/src")
     ->in(__DIR__ . "/tests");
@@ -49,7 +47,7 @@ It can be the case that you want to change something in the rules. No problem, y
 ```php
 <?php
 
-$config = new UptimeProject\PhpCsFixerConfig\Config([
+$config = new SandwaveIo\PhpCsFixerConfig\Config([
     'declare_strict_types' => true,
 ]);
 $config->getFinder()
@@ -75,7 +73,7 @@ $ruleOverrides = [
     'psr4' => false,
 ];
 
-$config = new UptimeProject\PhpCsFixerConfig\Config($ruleOverrides, false);
+$config = new SandwaveIo\PhpCsFixerConfig\Config($ruleOverrides, false);
 
 $config->getFinder()
     ->in(__DIR__ . '/src')
@@ -86,8 +84,8 @@ return $config;
 
 ## License
 
-The MIT License (MIT). Please see [License File](https://github.com/uptimeproject/php-cs-fixer-config/blob/main/LICENSE) for more information.
+The MIT License (MIT). Please see [License File](https://github.com/sandwave-io/php-cs-fixer-config/blob/main/LICENSE) for more information.
 
-## UptimeProject.io
+## Special thanks
 
-Check out [uptimeproject.io](https://uptimeproject.io)
+Special thanks to Jesse Kramer for the initial project!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sandwave-io/php-cs-fixer-config/CI?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sandwave-io/php-cs-fixer-config/ci.yml?branch=main)
 ![Packagist PHP Version Support](https://img.shields.io/packagist/php-v/sandwave-io/php-cs-fixer-config?style=flat-square)
 ![Packagist PHP Version Support](https://img.shields.io/packagist/v/sandwave-io/php-cs-fixer-config?style=flat-square)
 ![Packagist Downloads](https://img.shields.io/packagist/dt/sandwave-io/php-cs-fixer-config?style=flat-square)

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,6 @@
     },
     "license": "MIT",
     "authors": [
-        {
-            "name": "Jesse Kramer",
-            "email": "jesse@kramerventures.nl"
-        }
     ],
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sandwave-io/php-cs-fixer-config",
-    "description": "Common codestyle configuration for all UptimeProject.io PHP code.",
+    "description": "Common codestyle configuration for all Sandwave.io PHP code.",
     "type": "library",
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1",
@@ -11,7 +11,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "UptimeProject\\PhpCsFixerConfig\\": "src"
+            "SandwaveIo\\PhpCsFixerConfig\\": "src"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "uptimeproject/php-cs-fixer-config",
+    "name": "sandwave-io/php-cs-fixer-config",
     "description": "Common codestyle configuration for all UptimeProject.io PHP code.",
     "type": "library",
     "require": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -85,7 +85,7 @@ class Config extends BaseConfig
             'return_type_declaration' => ['space_before' => 'none'],
             'semicolon_after_instruction' => true,
             'short_scalar_cast' => true,
-            'single_blank_line_before_namespace' => true,
+            'blank_lines_before_namespace' => ['min_line_breaks' => 2, 'max_line_breaks' => 2],
             'single_quote' => true,
             'space_after_semicolon' => true,
             'standardize_not_equals' => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace UptimeProject\PhpCsFixerConfig;
+namespace SandwaveIo\PhpCsFixerConfig;
 
 use PhpCsFixer\Config as BaseConfig;
 
@@ -17,7 +17,7 @@ class Config extends BaseConfig
      */
     public function __construct(array $ruleOverrides = [], $allowRisky = true)
     {
-        parent::__construct('UptimeProject.io shared coding standard');
+        parent::__construct('Sandwave.io shared coding standard');
         $this->overrides = $ruleOverrides;
         $this->setRiskyAllowed($allowRisky);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config extends BaseConfig
 
     public function getRules(): array
     {
-        return array_merge([
+        $rules = array_merge([
             // Base rule sets
             '@PSR1' => true,
             '@PSR2' => true,
@@ -94,5 +94,10 @@ class Config extends BaseConfig
             'whitespace_after_comma_in_array' => true,
             'yoda_style' => false,
         ], $this->overrides);
+
+        // Order the rule sets: @PSR1, @PSR2, @PSR12 (instead of @PSR1, @PSR12, @PSR2)
+        uksort($rules, "strnatcmp");
+
+        return $rules;
     }
 }


### PR DESCRIPTION
See https://sandwaveio.atlassian.net/browse/WATER-5861

We can override PHP CS Fixer rules in each of our projects, but these are not properly put in the list of rules. So we might tell it to order the imports (“use” statements) but this is overwritten by the PSR12 rule set because that rule set is put at the end of the config array. And this in turn causes our imports to not be sorted.

tl;dr: Rule sets (that start with an “@“) should be placed on top of the config array.